### PR TITLE
fix: `implement-curry-with-placeholder` bug

### DIFF
--- a/2.md
+++ b/2.md
@@ -28,7 +28,7 @@ function mergeArgs(args, nextArgs) {
   let result = [];
   
   args.forEach((arg, idx) => {
-    if(arg == curry.placeholder) {
+    if(arg == curry.placeholder && nextArgs.length) {
       result.push(nextArgs.shift());
     } else {
       result.push(arg);


### PR DESCRIPTION
Whether to check `nextArgs.length` before its shift? 
Otherwise, the code below will get a `curriedJoin(...)(...) is not a function` error.

```js
const join = (a, b, c) => {
  return `${a}_${b}_${c}`
}
const curriedJoin = curry(join)
console.log(curriedJoin(_, _, _)(1)(_, 3)(2)) // '1_2_3'
```